### PR TITLE
Added Istanbul coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+coverage
 npm-debug.log
 node_modules
 bower_components

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ var browserify = require('gulp-browserify'),
     gulp = require('gulp'),
     gutil = require('gulp-util'),
     http = require('http'),
+    istanbul = require('gulp-istanbul'),
     merge = require('merge2'),
     mocha = require('gulp-mocha'),
     rename = require('gulp-rename'),
@@ -19,8 +20,14 @@ var browserify = require('gulp-browserify'),
 var config = new Config();
 
 gulp.task('test', function () {
-    return gulp.src(config.test, {read: false})
-        .pipe(mocha());
+    return gulp.src(config.server + config.lib)
+        .pipe(istanbul())
+        .pipe(istanbul.hookRequire())
+        .on('finish', function() {
+            gulp.src(config.test, {read: false})
+                .pipe(mocha())
+                .pipe(istanbul.writeReports());
+        });
 });
 
 gulp.task('clean', function (cb) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp": "^3.8.11",
     "gulp-browserify": "^0.5.1",
     "gulp-bump": "^0.3.1",
+    "gulp-istanbul": "^0.10.0",
     "gulp-mocha": "^2.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-tag-version": "^1.3.0",


### PR DESCRIPTION
This adds Istanbul code coverage support. With this, we'll be able to see a quick coverage percentage in the output on Travis, and if we run tests on our own servers, we'll also get a coverage directory containing a detailed HTML report showing exactly which lines lack coverage.

The coverage report applies to the compiled JS file rather than the original TypeScript, but I think this is adequate for figuring out what tests need to be written. (The TypeScript team suggested that they've found that direct TypeScript coverage reports don't add a lot of value since the JS is pretty recognizable).