### PR TITLE
Check if no metadata is present

### DIFF
--- a/src/ManifestResource.ts
+++ b/src/ManifestResource.ts
@@ -14,6 +14,9 @@ module Manifesto {
         getMetadata(): any{
             var metadata: Object[] = this.getProperty('metadata');
 
+            if (!metadata)
+                return [];
+
             // get localised value for each metadata item.
             for (var i = 0; i < metadata.length; i++) {
                 var item: any = metadata[i];


### PR DESCRIPTION
Hi Ed!

Just a quick bug fix for a crash if no metadata element were present in the manifest.